### PR TITLE
Implement Junie format converter

### DIFF
--- a/src/formats/junie.rs
+++ b/src/formats/junie.rs
@@ -1,14 +1,23 @@
 use super::{FromFormat, ToFormat};
-use crate::model::types::{InstructionItem, InstruxConfiguration};
+use crate::model::types::{
+    InstructionItem, InstructionItemVariant0Targets, InstructionItemVariant1Targets,
+    InstructionItemVariant2Targets, InstruxConfiguration, Targets,
+};
 use std::path::PathBuf;
 
 /// Converter for Junie format (.junie/guidelines.md)
 pub struct JunieConverter {}
 
 impl ToFormat for JunieConverter {
-    fn to_format(&self, _config: &InstruxConfiguration) -> Result<String, String> {
-        // TODO: Implement conversion to Junie format
-        Err("Not implemented yet".to_string())
+    fn to_format(&self, config: &InstruxConfiguration) -> Result<String, String> {
+        let mut output = String::new();
+
+        // Header
+        output.push_str("# Junie Guidelines\n\n");
+
+        process_instructions(&mut output, &config.instructions, 0)?;
+
+        Ok(output)
     }
 
     fn get_default_path(&self) -> PathBuf {
@@ -16,12 +25,167 @@ impl ToFormat for JunieConverter {
     }
 }
 
+/// Helper function to process instructions recursively for Junie format
+fn process_instructions(
+    output: &mut String,
+    instructions: &[InstructionItem],
+    level: usize,
+) -> Result<(), String> {
+    for instruction in instructions {
+        match instruction {
+            InstructionItem::Variant0 {
+                title,
+                body,
+                disable,
+                targets,
+                ..
+            } => {
+                if *disable {
+                    continue;
+                }
+
+                if !is_target_for_junie(targets) {
+                    continue;
+                }
+
+                output.push_str(&format!("{} {}\n\n", "#".repeat(level + 2), title));
+                output.push_str(body);
+                output.push_str("\n\n");
+            }
+            InstructionItem::Variant1 {
+                title,
+                body_file,
+                disable,
+                targets,
+                ..
+            } => {
+                if *disable {
+                    continue;
+                }
+
+                if !is_target_for_junie(targets) {
+                    continue;
+                }
+
+                output.push_str(&format!("{} {}\n\n", "#".repeat(level + 2), title));
+                output.push_str(&format!("<!-- Content from file: {} -->\n\n", body_file));
+            }
+            InstructionItem::Variant2 {
+                title,
+                instructions: nested,
+                disable,
+                targets,
+                ..
+            } => {
+                if *disable {
+                    continue;
+                }
+
+                if !is_target_for_junie(targets) {
+                    continue;
+                }
+
+                output.push_str(&format!("{} {}\n\n", "#".repeat(level + 2), title));
+                process_instructions(output, nested, level + 1)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn is_target_for_junie<T>(targets: &T) -> bool
+where
+    T: TargetsChecker,
+{
+    targets.is_for_junie()
+}
+
+trait TargetsChecker {
+    fn is_for_junie(&self) -> bool;
+}
+
+impl TargetsChecker for InstructionItemVariant0Targets {
+    fn is_for_junie(&self) -> bool {
+        match self {
+            InstructionItemVariant0Targets::Variant0(list) => list.contains(&Targets::Junie),
+            InstructionItemVariant0Targets::Variant1(s) => s == "all",
+        }
+    }
+}
+
+impl TargetsChecker for InstructionItemVariant1Targets {
+    fn is_for_junie(&self) -> bool {
+        match self {
+            InstructionItemVariant1Targets::Variant0(list) => list.contains(&Targets::Junie),
+            InstructionItemVariant1Targets::Variant1(s) => s == "all",
+        }
+    }
+}
+
+impl TargetsChecker for InstructionItemVariant2Targets {
+    fn is_for_junie(&self) -> bool {
+        match self {
+            InstructionItemVariant2Targets::Variant0(list) => list.contains(&Targets::Junie),
+            InstructionItemVariant2Targets::Variant1(s) => s == "all",
+        }
+    }
+}
+
 /// Parser for Junie format
 pub struct JunieParser {}
 
 impl FromFormat for JunieParser {
-    fn from_format(_content: &str) -> Result<Vec<InstructionItem>, String> {
-        // TODO: Implement parsing from Junie format
-        Err("Not implemented yet".to_string())
+    fn from_format(content: &str) -> Result<Vec<InstructionItem>, String> {
+        let mut instructions = Vec::new();
+
+        let mut sections = Vec::new();
+        let mut current_section = String::new();
+        let mut current_level = 0;
+        let mut current_title = String::new();
+
+        for line in content.lines() {
+            if line.starts_with('#') {
+                let level = line.chars().take_while(|&c| c == '#').count();
+                let title = line.trim_start_matches('#').trim().to_string();
+
+                if !current_title.is_empty() {
+                    sections.push((current_level, current_title.clone(), current_section.clone()));
+                    current_section.clear();
+                }
+
+                current_level = level;
+                current_title = title;
+            } else {
+                current_section.push_str(line);
+                current_section.push('\n');
+            }
+        }
+
+        if !current_title.is_empty() {
+            sections.push((current_level, current_title.clone(), current_section.clone()));
+        }
+
+        for (level, title, body) in sections {
+            if level <= 1 {
+                continue;
+            }
+
+            let instruction = InstructionItem::Variant0 {
+                title,
+                body: body.trim().to_string(),
+                description: None,
+                disable: false,
+                targets: InstructionItemVariant0Targets::Variant0(vec![Targets::Junie]),
+            };
+
+            instructions.push(instruction);
+        }
+
+        if instructions.is_empty() {
+            return Err("No valid instructions found in the Junie format file".to_string());
+        }
+
+        Ok(instructions)
     }
 }

--- a/src/formats/tests/junie_tests.rs
+++ b/src/formats/tests/junie_tests.rs
@@ -1,0 +1,90 @@
+#[cfg(test)]
+mod tests {
+    use crate::formats::{FromFormat, ToFormat, junie::JunieConverter, junie::JunieParser};
+    use crate::model::types::{
+        InstructionItem, InstructionItemVariant0Targets, InstruxConfiguration, Targets,
+    };
+    use std::collections::HashMap;
+
+    fn create_test_config() -> InstruxConfiguration {
+        let instruction1 = InstructionItem::Variant0 {
+            title: "Sample Instruction".to_string(),
+            body: "This is a sample instruction body.".to_string(),
+            description: Some("Description of the instruction".to_string()),
+            disable: false,
+            targets: InstructionItemVariant0Targets::Variant1("all".to_string()),
+        };
+
+        let instruction2 = InstructionItem::Variant0 {
+            title: "Junie Specific Instruction".to_string(),
+            body: "This instruction is specific to Junie.".to_string(),
+            description: None,
+            disable: false,
+            targets: InstructionItemVariant0Targets::Variant0(vec![Targets::Junie]),
+        };
+
+        let mut targets_map = HashMap::new();
+        targets_map.insert(Targets::Junie, Default::default());
+
+        let version = "0.1.0".parse().expect("Valid version string");
+
+        InstruxConfiguration {
+            instructions: vec![instruction1, instruction2],
+            language: Default::default(),
+            targets: targets_map,
+            version,
+        }
+    }
+
+    #[test]
+    fn test_junie_converter_to_format() {
+        let config = create_test_config();
+        let converter = JunieConverter {};
+
+        let result = converter.to_format(&config);
+        assert!(result.is_ok());
+
+        let output = result.unwrap();
+        assert!(output.contains("# Junie Guidelines"));
+        assert!(output.contains("## Sample Instruction"));
+        assert!(output.contains("This is a sample instruction body."));
+        assert!(output.contains("## Junie Specific Instruction"));
+        assert!(output.contains("This instruction is specific to Junie."));
+    }
+
+    #[test]
+    fn test_junie_parser_from_format() {
+        let sample_content = r#"# Junie Guidelines
+
+## Sample Instruction
+
+This is a sample instruction body.
+
+## Junie Specific Instruction
+
+This instruction is specific to Junie.
+"#;
+
+        let result = JunieParser::from_format(sample_content);
+        assert!(result.is_ok());
+
+        let instructions = result.unwrap();
+        assert_eq!(instructions.len(), 2);
+
+        match &instructions[0] {
+            InstructionItem::Variant0 { title, body, .. } => {
+                assert_eq!(title, "Sample Instruction");
+                assert!(body.contains("This is a sample instruction body."));
+            }
+            _ => panic!("Expected Variant0"),
+        }
+
+        match &instructions[1] {
+            InstructionItem::Variant0 { title, body, .. } => {
+                assert_eq!(title, "Junie Specific Instruction");
+                assert!(body.contains("This instruction is specific to Junie."));
+            }
+            _ => panic!("Expected Variant0"),
+        }
+    }
+}

--- a/src/formats/tests/mod.rs
+++ b/src/formats/tests/mod.rs
@@ -1,1 +1,2 @@
 mod copilot_tests;
+mod junie_tests;


### PR DESCRIPTION
## Summary
- implement `JunieConverter` and `JunieParser`
- add unit tests for Junie format

## Testing
- `cargo test -- --nocapture` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_684db0775e648328bb700e0b30ff9be0