### PR TITLE
Add Cline format converter

### DIFF
--- a/src/formats/cline.rs
+++ b/src/formats/cline.rs
@@ -1,14 +1,33 @@
+use super::common;
 use super::{FromFormat, ToFormat};
-use crate::model::types::{InstructionItem, InstruxConfiguration};
+use crate::model::types::{
+    InstructionItem, InstructionItemVariant0Targets, InstructionItemVariant1Targets,
+    InstructionItemVariant2Targets, InstruxConfiguration, Targets,
+};
 use std::path::PathBuf;
 
 /// Converter for Cline format (.clinerules)
 pub struct ClineConverter {}
 
 impl ToFormat for ClineConverter {
-    fn to_format(&self, _config: &InstruxConfiguration) -> Result<String, String> {
-        // TODO: Implement conversion to Cline format
-        Err("Not implemented yet".to_string())
+    fn to_format(&self, config: &InstruxConfiguration) -> Result<String, String> {
+        let mut output = String::new();
+
+        // Header for Cline format
+        output.push_str("# Cline Rules\n\n");
+
+        common::process_instructions_common(
+            &mut output,
+            &config.instructions,
+            0,
+            |item| match item {
+                InstructionItem::Variant0 { targets, .. } => is_target_for_cline(targets),
+                InstructionItem::Variant1 { targets, .. } => is_target_for_cline(targets),
+                InstructionItem::Variant2 { targets, .. } => is_target_for_cline(targets),
+            },
+        )?;
+
+        Ok(output)
     }
 
     fn get_default_path(&self) -> PathBuf {
@@ -16,12 +35,49 @@ impl ToFormat for ClineConverter {
     }
 }
 
+fn is_target_for_cline<T>(targets: &T) -> bool
+where
+    T: TargetsChecker,
+{
+    targets.is_for_cline()
+}
+
+trait TargetsChecker {
+    fn is_for_cline(&self) -> bool;
+}
+
+impl TargetsChecker for InstructionItemVariant0Targets {
+    fn is_for_cline(&self) -> bool {
+        match self {
+            InstructionItemVariant0Targets::Variant0(list) => list.contains(&Targets::Cline),
+            InstructionItemVariant0Targets::Variant1(s) => s == "all",
+        }
+    }
+}
+
+impl TargetsChecker for InstructionItemVariant1Targets {
+    fn is_for_cline(&self) -> bool {
+        match self {
+            InstructionItemVariant1Targets::Variant0(list) => list.contains(&Targets::Cline),
+            InstructionItemVariant1Targets::Variant1(s) => s == "all",
+        }
+    }
+}
+
+impl TargetsChecker for InstructionItemVariant2Targets {
+    fn is_for_cline(&self) -> bool {
+        match self {
+            InstructionItemVariant2Targets::Variant0(list) => list.contains(&Targets::Cline),
+            InstructionItemVariant2Targets::Variant1(s) => s == "all",
+        }
+    }
+}
+
 /// Parser for Cline format
 pub struct ClineParser {}
 
 impl FromFormat for ClineParser {
-    fn from_format(_content: &str) -> Result<Vec<InstructionItem>, String> {
-        // TODO: Implement parsing from Cline format
-        Err("Not implemented yet".to_string())
+    fn from_format(content: &str) -> Result<Vec<InstructionItem>, String> {
+        common::parse_markdown_instructions(content, Targets::Cline)
     }
 }

--- a/src/formats/tests/cline_tests.rs
+++ b/src/formats/tests/cline_tests.rs
@@ -1,0 +1,90 @@
+#[cfg(test)]
+mod tests {
+    use crate::formats::{FromFormat, ToFormat, cline::ClineConverter, cline::ClineParser};
+    use crate::model::types::{
+        InstructionItem, InstructionItemVariant0Targets, InstruxConfiguration, Targets,
+    };
+    use std::collections::HashMap;
+
+    fn create_test_config() -> InstruxConfiguration {
+        let instruction1 = InstructionItem::Variant0 {
+            title: "Sample Instruction".to_string(),
+            body: "This is a sample instruction body.".to_string(),
+            description: None,
+            disable: false,
+            targets: InstructionItemVariant0Targets::Variant1("all".to_string()),
+        };
+
+        let instruction2 = InstructionItem::Variant0 {
+            title: "Cline Specific Instruction".to_string(),
+            body: "This instruction is specific to Cline.".to_string(),
+            description: None,
+            disable: false,
+            targets: InstructionItemVariant0Targets::Variant0(vec![Targets::Cline]),
+        };
+
+        let mut targets_map = HashMap::new();
+        targets_map.insert(Targets::Cline, Default::default());
+
+        let version = "0.1.0".parse().expect("Valid version string");
+
+        InstruxConfiguration {
+            instructions: vec![instruction1, instruction2],
+            language: Default::default(),
+            targets: targets_map,
+            version,
+        }
+    }
+
+    #[test]
+    fn test_cline_converter_to_format() {
+        let config = create_test_config();
+        let converter = ClineConverter {};
+
+        let result = converter.to_format(&config);
+        assert!(result.is_ok());
+
+        let output = result.unwrap();
+        assert!(output.contains("# Cline Rules"));
+        assert!(output.contains("## Sample Instruction"));
+        assert!(output.contains("This is a sample instruction body."));
+        assert!(output.contains("## Cline Specific Instruction"));
+        assert!(output.contains("This instruction is specific to Cline."));
+    }
+
+    #[test]
+    fn test_cline_parser_from_format() {
+        let sample_content = r#"# Cline Rules
+
+## Sample Instruction
+
+This is a sample instruction body.
+
+## Cline Specific Instruction
+
+This instruction is specific to Cline.
+"#;
+
+        let result = ClineParser::from_format(sample_content);
+        assert!(result.is_ok());
+
+        let instructions = result.unwrap();
+        assert_eq!(instructions.len(), 2);
+
+        match &instructions[0] {
+            InstructionItem::Variant0 { title, body, .. } => {
+                assert_eq!(title, "Sample Instruction");
+                assert!(body.contains("This is a sample instruction body."));
+            }
+            _ => panic!("Expected Variant0"),
+        }
+
+        match &instructions[1] {
+            InstructionItem::Variant0 { title, body, .. } => {
+                assert_eq!(title, "Cline Specific Instruction");
+                assert!(body.contains("This instruction is specific to Cline."));
+            }
+            _ => panic!("Expected Variant0"),
+        }
+    }
+}

--- a/src/formats/tests/mod.rs
+++ b/src/formats/tests/mod.rs
@@ -1,2 +1,3 @@
+mod cline_tests;
 mod copilot_tests;
 mod junie_tests;


### PR DESCRIPTION
## Summary
- implement Cline format converter
- parse and generate `.clinerules` as markdown
- add tests for Cline converter

## Testing
- `cargo test --quiet`
- `cargo clippy --quiet -- -D warnings`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_684dc2cf72488328a21256085e46d583