### PR TITLE
Integrate cargo-llvm-cov for CI code coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,11 +26,23 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-
+    - name: Install llvm-tools
+      run: sudo apt-get update && sudo apt-get install -y llvm-tools
+    - name: Install cargo-llvm-cov
+      run: cargo install cargo-llvm-cov --locked
     - name: Format
       run: cargo fmt -- --check
     - name: Build
       run: cargo build --verbose
     - name: Test
       run: cargo test --verbose
+    - name: Generate code coverage
+      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} # Optional: add if you have a private repo or want to ensure uploads
+        files: lcov.info # Specify the coverage file
+        fail_ci_if_error: true # Optional: fail CI if Codecov upload fails
     - name: Clippy
       run: cargo clippy -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Generate code coverage
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         files: lcov.info
         fail_ci_if_error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,9 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+        components: llvm-tools-preview # Added for cargo-llvm-cov
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
     - name: Cache cargo registry
       uses: actions/cache@v3
       with:
@@ -26,23 +29,20 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-
-    - name: Install llvm-tools
-      run: sudo apt-get update && sudo apt-get install -y llvm-tools
-    - name: Install cargo-llvm-cov
-      run: cargo install cargo-llvm-cov --locked
     - name: Format
       run: cargo fmt -- --check
     - name: Build
       run: cargo build --verbose
     - name: Test
       run: cargo test --verbose
+    - name: Check cargo-llvm-cov version
+      run: cargo llvm-cov --version
     - name: Generate code coverage
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-        token: ${{ secrets.CODECOV_TOKEN }} # Optional: add if you have a private repo or want to ensure uploads
-        files: lcov.info # Specify the coverage file
-        fail_ci_if_error: true # Optional: fail CI if Codecov upload fails
+        files: lcov.info
+        fail_ci_if_error: true
     - name: Clippy
       run: cargo clippy -- -D warnings

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Instrux
 
 [![CI](https://github.com/epli2/instrux/actions/workflows/rust.yml/badge.svg)](https://github.com/epli2/instrux/actions/workflows/rust.yml)
+[![codecov](https://codecov.io/gh/epli2/instrux/branch/main/graph/badge.svg?token=YOUR_CODECOV_TOKEN_HERE)](https://codecov.io/gh/epli2/instrux)
+<!-- TODO: Replace YOUR_CODECOV_TOKEN_HERE with the actual token if needed, or remove if public repo and token is not strictly necessary -->
 
 WIP
 
@@ -82,3 +84,33 @@ instrx/                 # ← Git root / Cargo workspace
 #### instrux.yaml
 
 `schema/instrux.schema.json`参照
+
+## Code Coverage
+
+This project uses `cargo-llvm-cov` for code coverage. To generate a coverage report locally:
+
+1. Install `cargo-llvm-cov`:
+   ```bash
+   cargo install cargo-llvm-cov --locked
+   ```
+2. Install `llvm-tools`:
+   ```bash
+   # On Debian/Ubuntu
+   sudo apt-get update && sudo apt-get install -y llvm-tools
+   # On macOS (using Homebrew)
+   # brew install llvm
+   ```
+3. Run the coverage command from the root of the project:
+   ```bash
+   cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+   ```
+   This will generate an LCOV report at `lcov.info`. You can then use tools like `genhtml` (part of LCOV) to view it as HTML:
+   ```bash
+   # Install lcov if you don't have it
+   # sudo apt-get install lcov (Debian/Ubuntu)
+   # brew install lcov (macOS)
+   genhtml lcov.info --output-directory coverage-html
+   ```
+   Then open `coverage-html/index.html` in your browser.
+
+Coverage is also automatically tracked on CI using Codecov.


### PR DESCRIPTION
- Updated GitHub Actions workflow to install cargo-llvm-cov and llvm-tools.
- Added steps to generate LCOV report and upload to Codecov.
- Updated README.md with Codecov badge and local coverage generation instructions.